### PR TITLE
Fix ADMA FIFO reset

### DIFF
--- a/rtl/sd_emmc_controller.v
+++ b/rtl/sd_emmc_controller.v
@@ -257,6 +257,7 @@
             .write_timeout({d_read, d_write}),
             .descriptor_pointer_i(system_addr),
             .data_present(command_axi_clk[5]),
+            .cmd_start_puls(cmd_start_axi_clk),
             .cmd_compl_puls(cmd_cmplt_axi_puls),
             .blk_gap_req(stop_blk_gap_req)
         );

--- a/rtl/sd_emmc_controller_dma.v
+++ b/rtl/sd_emmc_controller_dma.v
@@ -66,6 +66,7 @@ module  sd_emmc_controller_dma (
             input wire [1:0] write_timeout,
             
             // Command master
+            input wire cmd_start_puls,
             input wire cmd_compl_puls,
             
             // FIFO Filler
@@ -442,7 +443,7 @@ localparam [2:0] ST_STOP = 3'b000, //State Stop DMA. ADMA2 stays in this state i
         else begin
           case (adma_state)
             ST_STOP: begin
-                       if (dma_ena_trans_mode & cmd_compl_puls & data_present /*& dat_int_rst*/) begin
+                       if (dma_ena_trans_mode & cmd_start_puls & data_present /*& dat_int_rst*/) begin
                          next_state <= ST_FDS;
                          sdma_contr_reg <= 12'h01E; //Read from SysRam, read to descriptor line, read from adma_descriptor_pointer addres, read two beats in burst, start read. 
                          rd_dat_words <= 17'h00008;


### PR DESCRIPTION
eMMC parts with shorter `N_AC` timing (down to the eMMC specification minimum of 2 cycles) may start returning read data sooner than the end of the command response serialization, which is what the `cmd_compl_puls` condition to move the ADMA FSM out of the IDLE state used to be. That results in the data receive FIFO being reset after some data has already been pushed.

This PR switches to using the `cmd_start_puls` as the condition to move the ADMA FSM out of the IDLE state. While this raises the theoretical possibility of delivering write data to the eMMC part "too soon," in practice the fact that the ADMA FSM has to do a descriptor fetch over AXI, kick off the SDMA FSM, which then has too fetch one whole block of data before the write data is serialized makes that possibility "impossible."