### PR TITLE
Choose pulse to start ADMA FSM based on transfer direction

### DIFF
--- a/rtl/sd_emmc_controller_dma.v
+++ b/rtl/sd_emmc_controller_dma.v
@@ -443,7 +443,7 @@ localparam [2:0] ST_STOP = 3'b000, //State Stop DMA. ADMA2 stays in this state i
         else begin
           case (adma_state)
             ST_STOP: begin
-                       if (dma_ena_trans_mode & cmd_start_puls & data_present /*& dat_int_rst*/) begin
+                       if (dma_ena_trans_mode & (dir_dat_trans_mode ? cmd_start_puls : cmd_compl_puls) & data_present /*& dat_int_rst*/) begin
                          next_state <= ST_FDS;
                          sdma_contr_reg <= 12'h01E; //Read from SysRam, read to descriptor line, read from adma_descriptor_pointer addres, read two beats in burst, start read. 
                          rd_dat_words <= 17'h00008;


### PR DESCRIPTION
As noted in 5dc30d1, the previous fix to use the `cmd_start_puls` to move the ADMA FSM out of the IDLE state had a chance of having data to send to the card "too soon." It turns out that in such a situation, the data doesn't go out too soon, but it never goes out and leaves the eMMC device waiting for the write data forever. This is because the `start_write` pulse sent to the data serializer comes at a point where its FSM is still waiting for the command response.

This PR changes the conditional to use `cmd_start_puls` for block reads and `cmd_compl_puls` for block writes.